### PR TITLE
Add CODEOWNERS file in .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,13 @@
-# This is a GitHub CODEOWNERS file
-# See https://help.github.com/articles/about-codeowners/ for more information
+# Each line is a file pattern followed by one or more owners.
+# More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# Default group from which to request review for all pull requests.
-*				@vmware/vic-maintainers
+# Default owner
+* @hashicorp/team-ip-compliance
 
-# Changes to this file should be reviewed by an admin
-/.github/CODEOWNERS		@vmware/vic-admins
-
-# Changes to documentation should be reviewed by someone from our IX team
-/doc/				@stuclem @alextopuzov
-
-# Changes to design documentation should be reviewed by our architect instead of IX
-/doc/design/			@hickeng
+# Add override rules below. Each line is a file/folder pattern followed by one or more owners.
+# Being an owner means those groups or individuals will be added as reviewers to PRs affecting
+# those areas of the code.
+# Examples:
+# /docs/  @docs-team
+# *.js    @js-team
+# *.go    @go-team


### PR DESCRIPTION
Add CODEOWNERS file to define code ownership rules.

This PR adds a CODEOWNERS file in `.github/CODEOWNERS` to help manage code review assignments and maintain clear ownership of different parts of the codebase.